### PR TITLE
`ProxyWebSocket`: Close connection on client read error

### DIFF
--- a/src/http_server/proxy/websocket/mod.rs
+++ b/src/http_server/proxy/websocket/mod.rs
@@ -1,6 +1,7 @@
 mod convert_message;
 mod proxy_message;
 mod proxy_websocket;
+mod stop_message;
 
 use super::auth::authenticate;
 use actix_web::error::ErrorServiceUnavailable;

--- a/src/http_server/proxy/websocket/stop_message.rs
+++ b/src/http_server/proxy/websocket/stop_message.rs
@@ -1,0 +1,5 @@
+use actix::Message;
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub(super) struct StopMessage;


### PR DESCRIPTION
Ensure the original WebSocket connection is properly closed by sending a `StopMessage` when reading from the client fails. This prevents lingering connections and ensures clean termination on error conditions.