### PR TITLE
Added "heartbeat" mechanism to websocket proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nullnet-libfireparse = "0.3.2"
 nullnet-liberror = "0.1.1"
 nullnet-liblogging = "0.3.0"
 nullnet-libipinfo = "0.2.0"
-nullnet-libtunnel = "0.3.2"
+nullnet-libtunnel = "0.3.3"
 etherparse = "0.18.0"
 tonic = { version = "0.13.1", features = ["_tls-any", "tls-native-roots"] }
 prost = "0.13.5"
@@ -43,7 +43,7 @@ hyper = { version = "1.6.0", features = [ "client", "http1", "http2" ] }
 hyper-util = { version = "0.1.10", features = ["client", "client-legacy", "http1"] }
 http-body-util = "0.1.3"
 actix-web-actors = "4.3.1"
-tokio-tungstenite = "0.26.2"
+tokio-tungstenite = { version = "0.26.2", features = ["handshake"] }
 actix = "0.13.5"
 futures-util = "0.3.31"
 rand = "0.9.0"


### PR DESCRIPTION
### Overview

This change adds a workaround to detect unexpected TCP stream resets that are not properly surfaced by the Tungstenite WebSocket implementation. By periodically sending WebSocket ping frames, we can trigger an error if the connection has silently broken, allowing the system to recover gracefully.

This is a temporary solution specifically for the TTY tunneling use case. In the long term, we should consider replacing the WebSocket layer on the WallGuard client side with a raw TCP stream, as WebSockets add unnecessary complexity for this scenario.

### Related issue
#3 